### PR TITLE
docs: add owasp cairo chapter july 2025

### DIFF
--- a/build.js
+++ b/build.js
@@ -23,7 +23,7 @@ const conferenceOrgs = [
   { id: "in-cyber-forum", years: ["2024"] },
   { id: "isaca", years: ["2024"] },
   { id: "mako-lab", years: ["2023", "2024"] },
-  { id: "owasp", subDirs: ["owasp-toronto", "owasp-vancouver", "owasp-atlanta"], years: ["2023", "2024", "2025"] },
+  { id: "owasp", subDirs: ["owasp-cairo", "owasp-toronto", "owasp-vancouver", "owasp-atlanta"], years: ["2023", "2024", "2025"] },
   { id: "rsa-usa", years: ["2024", "2025"] }
 ];
 

--- a/docs/conferences/owasp/owasp-cairo/2025/july/README.md
+++ b/docs/conferences/owasp/owasp-cairo/2025/july/README.md
@@ -1,0 +1,23 @@
+# [OWASP](https://www.owasp.org)
+## [OWASP Cairo Chapter | AI, Security, and Hacking Tools](https://www.meetup.com/owasp-cairo-chapter/events/309128826/?_xtd=gqFyqTQ3MTI5ODAyMqFwo2FwaQ%253D%253D&from=ref)
+
+<div class="event-image">
+  <img src="https://secure.meetupstatic.com/photos/event/4/7/8/f/highres_509418319.jpeg?w=750"
+       alt="OWASP Cairo Chapter Event"
+       style="max-width: 100%; height: auto;">
+</div>
+
+- **Talk title:** "[AI, Security, and Hacking Tools](https://www.meetup.com/owasp-cairo-chapter/events/309128826/?_xtd=gqFyqTQ3MTI5ODAyMqFwo2FwaQ%253D%253D&from=ref)"
+  - Thu, Jun 19 · 6:00 PM EDT
+  - **Abstract:**
+
+*🎙️ Ads – Staff AI Security Researcher @ Dreadnode*
+*Talk: Dreadnode, dyana: A Hacker’s Sandbox for Profiling ML Models, Binaries & Beyond*
+*What it’s about:*
+*Ads will introduce dyana, a tool that lets you safely run and inspect machine learning models, executables, and other artifacts. He’ll explain how dyana works, why it’s useful, and show a live demo of a backdoored ML model in action. You’ll * also see how you can use dyana in your own testing or response workflows.*
+
+- 🍿 **YouTube Recording** [TBC](TBC)
+- 📣 **Speaker card:**
+- 🗣️ **Social links:** [Here](https://www.linkedin.com/posts/owasp-cairo_ai-security-and-hacking-tools-sat-jul-activity-7348837080682102786-UayE/?utm_source=share&utm_medium=member_ios&rcm=ACoAAEjrM1ABe4mFQabKZ8zfULzqkcSMVmuWVek)
+
+----------------------------

--- a/docs/data/content-fixed.json
+++ b/docs/data/content-fixed.json
@@ -105,6 +105,14 @@
       "description": "Talks on AI/ML Security and LLM Application Safety"
     },
     {
+      "id": "owasp/owasp-cairo-2025",
+      "name": "OWASP CAIRO",
+      "path": "owasp/owasp-cairo",
+      "year": "2023",
+      "icon": "fas fa-shield-virus",
+      "description": "AI, Security, and Hacking Tools"
+    },
+    {
       "id": "owasp/owasp-atlanta-2023",
       "name": "OWASP ATLANTA",
       "path": "owasp/owasp-atlanta",

--- a/docs/data/content.json
+++ b/docs/data/content.json
@@ -105,6 +105,14 @@
       "description": "Talks on AI/ML Security and LLM Application Safety"
     },
     {
+      "id": "owasp/owasp-cairo-2025",
+      "name": "OWASP CAIRO",
+      "path": "owasp/owasp-cairo",
+      "year": "2023",
+      "icon": "fas fa-shield-virus",
+      "description": "AI, Security, and Hacking Tools"
+    },
+    {
       "id": "owasp/owasp-atlanta-2023",
       "name": "OWASP ATLANTA",
       "path": "owasp/owasp-atlanta",

--- a/docs/js/content-loader.js
+++ b/docs/js/content-loader.js
@@ -98,6 +98,15 @@ document.addEventListener('DOMContentLoaded', function() {
                 localPath: "conferences/rsa-usa/2024/may"
             },
             {
+                name: "OWASP Cairo",
+                year: "2025",
+                icon: "fas fa-shield-virus",
+                description: "AI, Security, and Hacking Tools",
+                path: "owasp/owasp-cairo",
+                subdir: "july",
+                localPath: "conferences/owasp/owasp-cairo/2025/july"
+            },
+            {
                 name: "OWASP Atlanta",
                 year: "2025",
                 icon: "fas fa-shield-virus",


### PR DESCRIPTION
## AI-Generated Summary

- Updated the OWASP configuration in build.js by adding "owasp-cairo" to the subDirs list.
- Added a new README file for the OWASP Cairo event (July 2025) with detailed event information and imagery.
- Included a new entry for OWASP Cairo in both content-fixed.json and content.json with corresponding metadata.
- Modified content-loader.js to load the new OWASP Cairo event data for July 2025.

---

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
