### PR TITLE
docs: add rhic cyber range bugcrowd july 25

### DIFF
--- a/docs/conferences/bugcrowd/2025/july/rhic/README.md
+++ b/docs/conferences/bugcrowd/2025/july/rhic/README.md
@@ -1,0 +1,7 @@
+# BugCrowd x Dreadnode Crucible: Rhode Island College Cyber Range (RHIC) 2025
+
+- 📄 **Slides (PDF):** [BugCrowd x Dreadnode Crucible: Rhode Island College Cyber Range (RHIC) 2025](Ads%20Dawson%20-%20BugCrowd%20x%20Dreadnode%20Crucible%20-%20Rhode%20Island%20College%20-%20July%2016%202025.pdf)
+- 📣 **Speaker card:** [Hacker Spotlight: Ads Dawson](https://www.bugcrowd.com/blog/hacker-spotlight-ads-dawson/)
+- 🗣️ **Speaker BugCrowd Author Blog:** [Here](https://www.bugcrowd.com/blog/author/ads-dawson/)
+
+------------------------------


### PR DESCRIPTION
## AI-Generated Summary

- Added a new PDF file containing the conference slides for BugCrowd x Dreadnode Crucible at Rhode Island College Cyber Range 2025.
- Created a README.md file for the RHIC conference folder.
- The README includes:
  - A link to the conference slides PDF.
  - Links to the speaker spotlight and the BugCrowd author blog.
- These changes improve the documentation and accessibility of conference materials.

---

This summary was generated with ❤️ by [rigging](https://rigging.dreadnode.io/)
