### PR TITLE
test: restore end-to-end CI coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,35 +31,34 @@ jobs:
         files: ./coverage/lcov.info
         fail_ci_if_error: false
 
-  # E2E tests disabled - need to be updated for new Flappy Bird implementation
-  # e2e-tests:
-  #   runs-on: ubuntu-latest
-  #   
-  #   steps:
-  #   - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-  #   
-  #   - name: Setup Node.js
-  #     uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-  #     with:
-  #       node-version: '24'
-  #       cache: 'npm'
-  #   
-  #   - name: Install dependencies
-  #     run: npm ci
-  #   
-  #   - name: Install Playwright Browsers
-  #     run: npx playwright install --with-deps
-  #   
-  #   - name: Run E2E tests
-  #     run: npm run test:e2e
-  #   
-  #   - name: Upload Playwright Report
-  #     uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-  #     if: always()
-  #     with:
-  #       name: playwright-report
-  #       path: playwright-report/
-  #       retention-days: 30
+  e2e-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+    - name: Setup Node.js
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+      with:
+        node-version: '24'
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+
+    - name: Run E2E tests
+      run: npm run test:e2e
+
+    - name: Upload Playwright Report
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      if: always()
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30
 
   lint:
     runs-on: ubuntu-latest

--- a/__tests__/e2e.spec.js
+++ b/__tests__/e2e.spec.js
@@ -1,6 +1,6 @@
 const { test, expect } = require('@playwright/test');
 
-const BASE_URL = 'http://localhost:8080';
+const BASE_URL = 'http://localhost:8081';
 
 test.describe('Flappy Portfolio E2E Tests', () => {
     test.beforeEach(async ({ page }) => {
@@ -72,24 +72,20 @@ test.describe('Flappy Portfolio E2E Tests', () => {
         expect(await cards.count()).toBeGreaterThan(0);
     });
 
-    test('should navigate to content viewer when card clicked', async ({ page, context }) => {
-        const [newPage] = await Promise.all([
-            context.waitForEvent('page'),
-            page.click('.content-card:first-child')
+    test('should navigate to content viewer when a local card is clicked', async ({ page }) => {
+        const card = page.locator('.content-card[href*="content-viewer"]').first();
+        await expect(card).toBeVisible();
+
+        await Promise.all([
+            page.waitForURL(/content-viewer/),
+            card.click()
         ]);
-        
-        await expect(newPage).toHaveURL(/content-viewer/);
     });
 
-    test('should save high score to localStorage', async ({ page }) => {
-        await page.click('#game-canvas');
-        await page.waitForTimeout(100);
-        
-        const highScore = await page.evaluate(() => {
-            return localStorage.getItem('flappyHighScore');
-        });
-        
-        expect(highScore).not.toBeNull();
+    test('should load a saved high score from localStorage', async ({ page }) => {
+        await page.addInitScript(() => localStorage.setItem('flappyHighScore', '7'));
+        await page.reload();
+        await expect(page.locator('#high-score')).toHaveText('7');
     });
 
     test('should be responsive on mobile', async ({ page }) => {
@@ -107,6 +103,6 @@ test.describe('Content Viewer E2E Tests', () => {
 
     test('should have back button', async ({ page }) => {
         await page.goto(`${BASE_URL}/content-viewer.html?type=conference&org=apidays&year=2023`);
-        await expect(page.locator('.btn-back')).toBeVisible();
+        await expect(page.locator('.back-link')).toBeVisible();
     });
 });

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -12,7 +12,7 @@ module.exports = {
     reporter: 'html',
     use: {
         actionTimeout: 0,
-        baseURL: 'http://localhost:8080',
+        baseURL: 'http://localhost:8081',
         trace: 'on-first-retry',
         screenshot: 'only-on-failure'
     },
@@ -37,8 +37,8 @@ module.exports = {
         }
     ],
     webServer: {
-        command: 'npx http-server docs -p 8080',
-        port: 8080,
+        command: 'npx http-server docs -p 8081',
+        port: 8081,
         reuseExistingServer: !process.env.CI
     }
 };


### PR DESCRIPTION
Repairs the Playwright test-server port conflict, corrects navigation and high-score assertions, and re-enables the SHA-pinned E2E GitHub Actions job.